### PR TITLE
Feature/autofill login

### DIFF
--- a/lib/pages/sign_in_page.dart
+++ b/lib/pages/sign_in_page.dart
@@ -95,27 +95,34 @@ class _SignInPageState extends State<SignInPage> {
                     validator: (value) => Validation.isValidServerUrl(value),
                   ),
 
-                  // Username or email text field
-                  TextFormField(
-                      decoration: const InputDecoration(
-                        labelText: 'Username or email',
-                      ),
-                      controller: _identifierController,
-                      validator: (value) =>
-                          Validation.isNotEmptyString(value, 'Username')),
+                  AutofillGroup(
+                      child: Column(
+                    children: [
+                      TextFormField(
+                          decoration: const InputDecoration(
+                            labelText: 'Username or email',
+                          ),
+                          autofillHints: const [AutofillHints.username],
+                          controller: _identifierController,
+                          validator: (value) =>
+                              Validation.isNotEmptyString(value, 'Username')),
 
-                  // Password text field
-                  TextFormField(
-                    decoration: const InputDecoration(
-                      labelText: 'Password',
-                    ),
-                    obscureText: true,
-                    enableSuggestions: false,
-                    autocorrect: false,
-                    controller: _passwordController,
-                    validator: (value) =>
-                        Validation.isNotEmptyString(value, 'Password'),
-                  ),
+                      // Password text field
+                      TextFormField(
+                        decoration: const InputDecoration(
+                          labelText: 'Password',
+                        ),
+                        obscureText: true,
+                        enableSuggestions: false,
+                        autocorrect: false,
+                        autofillHints: const [AutofillHints.password],
+                        controller: _passwordController,
+                        validator: (value) =>
+                            Validation.isNotEmptyString(value, 'Password'),
+                      ),
+                    ],
+                  )),
+                  // Username or email text field
 
                   Padding(
                     padding: const EdgeInsets.fromLTRB(0, 15, 0, 0),

--- a/lib/pages/sign_in_page.dart
+++ b/lib/pages/sign_in_page.dart
@@ -1,4 +1,5 @@
 import 'package:airauth/service/authentication.dart';
+import 'package:airauth/service/validation.dart';
 import 'package:flutter/material.dart';
 import '../service/popup.dart';
 
@@ -18,6 +19,9 @@ class _SignInPageState extends State<SignInPage> {
   // Logos.
   static const _lightLogo = AssetImage('images/logo/light-logo.png');
   static const _darkLogo = AssetImage('images/logo/dark-logo.png');
+
+  // Create a global key that uniquely identifies the Form widget.
+  final _formKey = GlobalKey<FormState>();
 
   @override
   void initState() {
@@ -71,60 +75,73 @@ class _SignInPageState extends State<SignInPage> {
         Container(
           margin: const EdgeInsets.all(30),
           child: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                Image(
-                  image: isDark ? _lightLogo : _darkLogo,
-                  height: 65,
-                  width: 200,
-                ),
-                // Server address input
-                TextField(
-                  decoration: const InputDecoration(
-                    labelText: 'Server address',
-                    hintText: 'https://airauth.example.com:7331',
+            child: Form(
+              key: _formKey,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  Image(
+                    image: isDark ? _lightLogo : _darkLogo,
+                    height: 65,
+                    width: 200,
                   ),
-                  controller: _serverAddressController,
-                ),
-
-                // Username or email text field
-                TextField(
+                  // Server address input
+                  TextFormField(
                     decoration: const InputDecoration(
-                      labelText: 'Username or email',
+                      labelText: 'Server address',
+                      hintText: 'https://airauth.example.com:7331',
                     ),
-                    controller: _identifierController),
-
-                // Password text field
-                TextField(
-                  decoration: const InputDecoration(
-                    labelText: 'Password',
+                    controller: _serverAddressController,
+                    validator: (value) => Validation.isValidServerUrl(value),
                   ),
-                  obscureText: true,
-                  enableSuggestions: false,
-                  autocorrect: false,
-                  controller: _passwordController,
-                ),
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(0, 15, 0, 0),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: <Widget>[
-                      // Sign up button
-                      ElevatedButton(
-                        onPressed: signUp,
-                        child: const Text('Sign up'),
-                      ),
 
-                      // Sign in button
-                      ElevatedButton(
-                        onPressed: signIn,
-                        child: const Text('Sign in'),
+                  // Username or email text field
+                  TextFormField(
+                      decoration: const InputDecoration(
+                        labelText: 'Username or email',
                       ),
-                    ],
+                      controller: _identifierController,
+                      validator: (value) =>
+                          Validation.isNotEmptyString(value, 'Username')),
+
+                  // Password text field
+                  TextFormField(
+                    decoration: const InputDecoration(
+                      labelText: 'Password',
+                    ),
+                    obscureText: true,
+                    enableSuggestions: false,
+                    autocorrect: false,
+                    controller: _passwordController,
+                    validator: (value) =>
+                        Validation.isNotEmptyString(value, 'Password'),
                   ),
-                )
-              ],
+
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(0, 15, 0, 0),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: <Widget>[
+                        // Sign up button
+                        ElevatedButton(
+                          onPressed: signUp,
+                          child: const Text('Sign up'),
+                        ),
+
+                        // Sign in button
+                        ElevatedButton(
+                          onPressed: () {
+                            if (_formKey.currentState!.validate()) {
+                              signIn();
+                            }
+                          },
+                          child: const Text('Sign in'),
+                        ),
+                      ],
+                    ),
+                  )
+                ],
+              ),
             ),
           ),
         )

--- a/lib/pages/sign_up_page.dart
+++ b/lib/pages/sign_up_page.dart
@@ -113,6 +113,7 @@ class _SignUpPageState extends State<SignUpPage> {
                       decoration: const InputDecoration(
                         labelText: 'Username',
                       ),
+                      autofillHints: const [AutofillHints.username],
                       validator: (value) => Validation.isValidUsername(value),
                       controller: _usernameController),
 
@@ -120,6 +121,7 @@ class _SignUpPageState extends State<SignUpPage> {
                   TextFormField(
                       decoration: const InputDecoration(
                           labelText: 'Email', hintText: 'example@example.com'),
+                      autofillHints: const [AutofillHints.email],
                       validator: (value) => Validation.isValidEmail(value),
                       controller: _emailController),
 
@@ -128,6 +130,7 @@ class _SignUpPageState extends State<SignUpPage> {
                       decoration: const InputDecoration(
                         labelText: 'Phone number (optional)',
                       ),
+                      autofillHints: const [AutofillHints.telephoneNumber],
                       validator: (value) =>
                           Validation.isValidPhoneNumber(value),
                       controller: _phoneController),
@@ -138,6 +141,7 @@ class _SignUpPageState extends State<SignUpPage> {
                       labelText: 'Password',
                       errorMaxLines: 2,
                     ),
+                    autofillHints: const [AutofillHints.password],
                     obscureText: true,
                     enableSuggestions: false,
                     autocorrect: false,
@@ -150,6 +154,7 @@ class _SignUpPageState extends State<SignUpPage> {
                     decoration: const InputDecoration(
                       labelText: 'Confirm Password',
                     ),
+                    autofillHints: const [AutofillHints.password],
                     obscureText: true,
                     enableSuggestions: false,
                     autocorrect: false,

--- a/lib/service/validation.dart
+++ b/lib/service/validation.dart
@@ -30,6 +30,14 @@ class Validation {
     }
   }
 
+  // Check if the given value is a string and not empty.
+  static String? isNotEmptyString(dynamic str, String fieldName) {
+    if (!isString(str) || str == '') {
+      return '$fieldName is required.';
+    }
+    return null;
+  }
+
   /// Check if the given string is a valid username.
   static String? isValidUsername(String? username) {
     if (username == null) return 'Username is required';


### PR DESCRIPTION
This PR is based on #49, so I would recommend merging that one first.

Resolves #29 for the most part. Apparently, flutter does not support the "classic" style of autofill for password managers (accessibility options) and instead you must use a native auto-fill service. That however now works both on the sign in page and sign up page.