### PR TITLE
Refresh JWT token on start

### DIFF
--- a/lib/pages/loading_page.dart
+++ b/lib/pages/loading_page.dart
@@ -12,6 +12,7 @@ class _LoadingPageState extends State<LoadingPage> {
   /// Check sign in status and navigate to the next page.
   void checkSignInStatus(BuildContext context) async {
     if (await Authentication.isLoggedIn()) {
+      Authentication.refreshToken();
       Navigator.pushReplacementNamed(context, '/home');
     } else {
       Navigator.pushReplacementNamed(context, '/signin');


### PR DESCRIPTION
On start, if sign in status is found to be that the user is signed in. Send a request to the server to receive a new JWT with a newer expiration time.

Co-authored-by: Felix Bjerhem Aronsson <felix.b.aronsson@gmail.com>